### PR TITLE
Remove double url in item

### DIFF
--- a/_includes/components/item.njk
+++ b/_includes/components/item.njk
@@ -2,7 +2,6 @@
 {% macro item(discovery, date=true) %}
     <section>
         <a href="{{ discovery.url }}"><h2>{{discovery.name}}</h2></a>
-        <a href="{{ discovery.url }}">{{discovery.url}}</a>
         <p>{{discovery.description}}</p>
         <a href="/ep/{{discovery.episode.name | ep_num}}">Episode {{discovery.episode.name | ep_num}}</a>
         {% if date %}


### PR DESCRIPTION
Just a suggestion (feel free to ignore) but as the url for the discovery is printed twice (one with the discovery name as the big heading, and again underneath with the url as the link text), maybe it would have a cleaner look if one is removed?

If people want to know the discovery url, they can always hover over.

![pic-selected-220802-2122-12](https://user-images.githubusercontent.com/13795113/182464369-bec2fb15-2e12-4688-838f-42dbde0446b1.png)